### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -13,6 +13,9 @@ jobs:
   merge:
     name: "Merge"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      pull-requests: write
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION
Potential fix for [https://github.com/impresscms-dev/filter-php-class-list-with-glob-like-rules-action/security/code-scanning/3](https://github.com/impresscms-dev/filter-php-class-list-with-glob-like-rules-action/security/code-scanning/3)

To fix the issue, a `permissions` section needs to be explicitly set to the job or workflow to restrict `GITHUB_TOKEN` usage to the minimum required for the workflow steps. For this specific workflow, the merge and approval actions only need to interact with pull requests and, potentially, have read access for repository contents. The best way to fix it is to add a `permissions:` block just above the `steps:` in the `merge` job, setting `contents: read` and `pull-requests: write`. This limits the job to only what it needs. No imports or special definitions are required since this is a YAML workflow change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add explicit permissions for `contents: read` and `pull-requests: write` to the "Merge" job in the GitHub workflow `dependabot.yml`.

### Why are these changes being made?

This change addresses a code scanning alert indicating that the workflow lacked defined permissions, which is a security vulnerability. Specifying the necessary permissions explicitly ensures that the workflow has the least privilege needed for its actions, enhancing security and maintaining compliance with GitHub's best practices.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->